### PR TITLE
T7919 list lab token values

### DIFF
--- a/kci_admin/lab.py
+++ b/kci_admin/lab.py
@@ -18,6 +18,7 @@
 from . import request as kci_request
 from . import request_get as kci_request_get
 from . import parser as kci_parser
+from . import token
 
 
 description_create = "Create a lab entry"
@@ -70,5 +71,10 @@ def request_create(hostname, opts):
 
 
 def get_list(hostname):
+    tokens = token.get_dict(hostname)
     data = kci_request_get(hostname, "/lab")
+    labs = data["result"]
+    for lab in labs:
+        token_id = lab['token']['$oid']
+        lab['token'] = tokens[token_id]['token']
     return data['result']

--- a/kci_admin/token.py
+++ b/kci_admin/token.py
@@ -61,3 +61,8 @@ def request_create(hostname, payload):
 def get_list(hostname):
     data = kci_request_get(hostname, "/token")
     return data['result']
+
+
+def get_dict(hostname):
+    tokens_list = get_list(hostname)
+    return {t['_id']['$oid']: t for t in tokens_list}


### PR DESCRIPTION
Directly show the token values in `list_labs` instead of showing their ids.  This fixes #6.